### PR TITLE
Automate Docker Hub release publishing

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,100 @@
+name: Publish release image
+
+on:
+  push:
+    branches:
+      - release
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dockerhub-release-publish
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: magiccodingman/vllm-radiance
+  VERSION_SERIES: "1.0"
+
+jobs:
+  publish:
+    name: Build and publish Docker image
+    runs-on: [self-hosted, Linux, X64]
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+
+      - name: Generate image version
+        id: version
+        shell: bash
+        run: |
+          version="${VERSION_SERIES}.${GITHUB_RUN_NUMBER}"
+          short_sha="${GITHUB_SHA:0:12}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "short_sha=${short_sha}" >> "${GITHUB_OUTPUT}"
+          echo "Publishing ${IMAGE_NAME}:${version}"
+
+      - name: Validate build inputs
+        shell: bash
+        run: |
+          test -s Dockerfile
+          test -s README.md
+          test -s VERSION
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          keep-state: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          pull: true
+          build-args: |
+            RADIANCE_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION_SERIES }}
+            ${{ env.IMAGE_NAME }}:sha-${{ steps.version.outputs.short_sha }}
+            ${{ env.IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.title=vllm-radiance
+            org.opencontainers.image.description=vLLM inference server for AMD Radeon AI PRO R9700
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
+      - name: Publish GitHub README to Docker Hub
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          readme-filepath: ./README.md
+
+      - name: Write publish summary
+        shell: bash
+        run: |
+          {
+            echo "## Docker image published"
+            echo
+            echo "- \`${IMAGE_NAME}:${{ steps.version.outputs.version }}\`"
+            echo "- \`${IMAGE_NAME}:${VERSION_SERIES}\`"
+            echo "- \`${IMAGE_NAME}:sha-${{ steps.version.outputs.short_sha }}\`"
+            echo "- \`${IMAGE_NAME}:latest\`"
+            echo
+            echo "Docker Hub overview updated from \`README.md\`."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - release
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- publish `magiccodingman/vllm-radiance` whenever changes land on the `release` branch
- generate an automatic immutable version as `1.0.<workflow run number>`
- also publish `1.0`, `sha-<commit>`, and `latest` tags
- pass the generated version into the Docker build as `RADIANCE_VERSION`
- update the Docker Hub repository overview from this repository's `README.md`
- serialize releases so expensive source builds never overlap

## Credentials

Uses the existing repository secrets:

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## Runner requirement

The image builds PyTorch, Triton, AITER, torchvision, and vLLM from source and needs substantially more disk/time than a standard GitHub-hosted runner. The workflow therefore targets a persistent self-hosted Linux x64 runner. The repository runner needs Docker with Buildx available; no GPU is required for the image build.

## Trigger

Only a push or merge to `release` starts the build and publication. This preserves `release` as the deployment gate.
