### PR TITLE
Use GitHub-hosted runner for Docker publishing

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   publish:
     name: Build and publish Docker image
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out release source
@@ -46,7 +46,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-          keep-state: true
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- run the Docker publishing job on GitHub's hosted Ubuntu 24.04 runner
- remove the Buildx `keep-state` option that only benefits persistent self-hosted runners
- keep the existing release trigger, automatic version tags, Docker Hub publishing, and README synchronization unchanged

This fixes release jobs waiting indefinitely for unavailable `self-hosted, Linux, X64` labels.

## After merging

Merge this PR into `main`, then merge `main` into `release`. That push to `release` will start the corrected publishing workflow.